### PR TITLE
Add closing DIV to link generator

### DIFF
--- a/pocket-wp.php
+++ b/pocket-wp.php
@@ -420,6 +420,7 @@ class PocketWP {
 		  		} else {
 		  			$html[] ='<p class="pwp_tag_list"></p>';
 		  		}
+		  		$html[] = '</div>';
 		  	}
 		
 		    if (strtolower($credit) == "yes") {


### PR DESCRIPTION
There is not closing DIV for the link generator which causes problems when displayed on a page.
